### PR TITLE
feat: eslint 增加對 TypeScript 設定

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,6 +11,19 @@ module.exports = {
   plugins: ['react-refresh'],
   rules: {
     'semi': ['error', 'always'],
+    '@typescript-eslint/member-delimiter-style': [
+      'error',
+      {
+        'multiline': { 
+          'delimiter': 'semi',
+          'requireLast': true,
+        },
+        'singleline': {
+          'delimiter': 'semi',
+          'requireLast': false,
+        },
+      }
+    ],
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true },


### PR DESCRIPTION
TypeScript 定義 type or interface 時
不同 properties 用 `;` 隔開

Info from https://stackoverflow.com/questions/65388160/how-to-enforce-semicolon-in-typescript-interface